### PR TITLE
Add notification abstraction layer for multi-channel dispatch

### DIFF
--- a/apps/api/src/services/notification.service.ts
+++ b/apps/api/src/services/notification.service.ts
@@ -1,0 +1,77 @@
+import type { ChannelConfig, ChannelType, NotificationPayload } from "../types";
+import type { Env } from "../types/env";
+import { sendDiscordNotification } from "./discord.service";
+import { sendTelegramNotification } from "./telegram.service";
+
+export interface NotificationResult {
+  channelType: ChannelType;
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Send notifications to all enabled channels for a user.
+ * Failures are isolated - one channel failing won't block others.
+ */
+export async function notifyUser(
+  channels: ChannelConfig[],
+  payload: NotificationPayload,
+  env: Env,
+): Promise<NotificationResult[]> {
+  const enabledChannels = channels.filter((channel) => channel.enabled);
+
+  if (enabledChannels.length === 0) {
+    return [];
+  }
+
+  const results = await Promise.allSettled(
+    enabledChannels.map((channel) => sendToChannel(channel, payload, env)),
+  );
+
+  return results.map((result, index) => {
+    const channel = enabledChannels[index];
+
+    if (result.status === "fulfilled") {
+      return {
+        channelType: channel.type,
+        success: true,
+      };
+    }
+
+    return {
+      channelType: channel.type,
+      success: false,
+      error:
+        result.reason instanceof Error
+          ? result.reason.message
+          : "Unknown error",
+    };
+  });
+}
+
+async function sendToChannel(
+  channel: ChannelConfig,
+  payload: NotificationPayload,
+  env: Env,
+): Promise<void> {
+  switch (channel.type) {
+    case "telegram":
+      await sendTelegramNotification(
+        env.TELEGRAM_BOT_TOKEN,
+        channel.chatId,
+        payload,
+      );
+      break;
+
+    case "discord":
+      await sendDiscordNotification(channel.webhookUrl, payload);
+      break;
+
+    default: {
+      const exhaustiveCheck: never = channel;
+      throw new Error(
+        `Unknown channel type: ${(exhaustiveCheck as ChannelConfig).type}`,
+      );
+    }
+  }
+}

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -1,5 +1,13 @@
 import type { AIAnalysisResult } from "../services/ai.service";
 
+// Re-export channel types from shared package
+export type {
+  ChannelConfig,
+  ChannelType,
+  DiscordChannelConfig,
+  TelegramChannelConfig,
+} from "@release-watch/types";
+
 // Notification payload
 export interface NotificationPayload {
   repoName: string;


### PR DESCRIPTION
## Summary
- Add `notification.service.ts` with `notifyUser()` that dispatches to all enabled channels
- Supports Telegram and Discord with isolated failure handling (one channel failing doesn't block others)