### PR TITLE
Potential fix for code scanning alert no. 1: Missing regular expression anchor

### DIFF
--- a/apps/api/src/bot/index.ts
+++ b/apps/api/src/bot/index.ts
@@ -382,7 +382,7 @@ export function createBot(): Bot {
     const match = text.match(GITHUB_URL_PATTERN);
 
     if (!match) {
-      if (/github\.com/i.test(text)) {
+      if (/^(?:https?:\/\/)?(?:www\.)?github\.com(?:\/|$)/i.test(text.trim())) {
         await ctx.reply(
           "That doesn't look like a GitHub repo URL. Try https://github.com/owner/repo",
         );


### PR DESCRIPTION
Potential fix for [https://github.com/tartinerlabs/shipradar/security/code-scanning/1](https://github.com/tartinerlabs/shipradar/security/code-scanning/1)

Use an anchored regex for the fallback GitHub-domain hint check so it only matches text that is actually a GitHub URL/host form, not arbitrary substrings.

Best fix in this file:
- In `apps/api/src/bot/index.ts`, update line 385’s `/github\.com/i.test(text)` to an anchored, host-aware expression such as:
  - `/^(?:https?:\/\/)?(?:www\.)?github\.com(?:\/|$)/i.test(text.trim())`
- This preserves existing behavior intent (“contains a GitHub URL-like input”) while preventing matches where `github.com` appears in query strings or unrelated text.
- No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
