### PR TITLE
Move system stats from the API to the web data layer

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -10,7 +10,6 @@ import health from "./routes/health";
 // import internal from "./routes/internal";
 
 // import repos from "./routes/repos";
-// import stats from "./routes/stats";
 
 // import webhook from "./routes/webhook";
 
@@ -26,7 +25,6 @@ const app = new Hono()
   .use("*", requestId())
   .route("/", health)
   .route("/health", health)
-  // .route("/", stats)
   // .route("/", webhook)
   // .route("/internal", internal)
   // .route("/", api)

--- a/apps/api/src/routes/stats.ts
+++ b/apps/api/src/routes/stats.ts
@@ -1,9 +1,0 @@
-import { Hono } from "hono";
-import { getSystemStats } from "../services/stats.service";
-
-const app = new Hono().basePath("/stats").get("/", async (c) => {
-  const stats = await getSystemStats();
-  return c.json(stats);
-});
-
-export default app;

--- a/apps/api/src/services/stats.service.ts
+++ b/apps/api/src/services/stats.service.ts
@@ -1,45 +1,7 @@
-import { db, userRepos } from "@shipradar/database";
 import { redis } from "@shipradar/redis";
-import type { SystemStats } from "@shipradar/types";
-import { getAllTrackedRepos } from "./kv.service";
 
 const NOTIFICATIONS_SENT_KEY = "notifications:sent";
 const RELEASES_NOTIFIED_KEY = "releases:notified";
-
-async function computeStats(): Promise<
-  Pick<SystemStats, "uniqueUsers" | "reposWatched" | "reposTracked">
-> {
-  const [trackedReposMap, dbTrackedRepos] = await Promise.all([
-    getAllTrackedRepos(),
-    db
-      .select({ userId: userRepos.userId, repoName: userRepos.repoName })
-      .from(userRepos),
-  ]);
-
-  const uniqueUsersSet = new Set<string>();
-  const allRepos = new Set<string>();
-  let reposTracked = 0;
-
-  for (const [chatId, repos] of trackedReposMap) {
-    uniqueUsersSet.add(`telegram:${chatId}`);
-    reposTracked += repos.length;
-    for (const repo of repos) {
-      allRepos.add(repo);
-    }
-  }
-
-  for (const row of dbTrackedRepos) {
-    uniqueUsersSet.add(`user:${row.userId}`);
-    allRepos.add(row.repoName);
-    reposTracked++;
-  }
-
-  return {
-    uniqueUsers: uniqueUsersSet.size,
-    reposWatched: allRepos.size,
-    reposTracked,
-  };
-}
 
 export async function incrementNotificationsSent(amount = 1): Promise<number> {
   return redis.incrby(NOTIFICATIONS_SENT_KEY, amount);
@@ -47,18 +9,4 @@ export async function incrementNotificationsSent(amount = 1): Promise<number> {
 
 export async function incrementReleasesNotified(amount = 1): Promise<number> {
   return redis.incrby(RELEASES_NOTIFIED_KEY, amount);
-}
-
-export async function getSystemStats(): Promise<SystemStats> {
-  const [computed, notificationsSent, releasesNotified] = await Promise.all([
-    computeStats(),
-    redis.get<number>(NOTIFICATIONS_SENT_KEY),
-    redis.get<number>(RELEASES_NOTIFIED_KEY),
-  ]);
-
-  return {
-    ...computed,
-    notificationsSent: notificationsSent ?? 0,
-    releasesNotified: releasesNotified ?? 0,
-  };
 }

--- a/apps/web/src/lib/data/stats.ts
+++ b/apps/web/src/lib/data/stats.ts
@@ -1,0 +1,43 @@
+import { db, userRepos } from "@shipradar/database";
+import { redis } from "@shipradar/redis";
+import type { SystemStats } from "@shipradar/types";
+
+// System-wide stats are global (not user-specific), so use shared `use cache`.
+export async function getSystemStats(): Promise<SystemStats> {
+  "use cache";
+
+  const [chatKeys, dbRepos, notificationsSent, releasesNotified] =
+    await Promise.all([
+      redis.keys("repos:chat:*"),
+      db
+        .select({ userId: userRepos.userId, repoName: userRepos.repoName })
+        .from(userRepos),
+      redis.get<number>("notifications:sent"),
+      redis.get<number>("releases:notified"),
+    ]);
+
+  const users = new Set<string>();
+  const repos = new Set<string>();
+  let reposTracked = 0;
+
+  for (const key of chatKeys) {
+    const tracked = (await redis.get<string[]>(key)) ?? [];
+    users.add(`telegram:${key.replace("repos:chat:", "")}`);
+    reposTracked += tracked.length;
+    for (const repo of tracked) repos.add(repo);
+  }
+
+  for (const row of dbRepos) {
+    users.add(`user:${row.userId}`);
+    repos.add(row.repoName);
+    reposTracked++;
+  }
+
+  return {
+    uniqueUsers: users.size,
+    reposWatched: repos.size,
+    reposTracked,
+    notificationsSent: notificationsSent ?? 0,
+    releasesNotified: releasesNotified ?? 0,
+  };
+}


### PR DESCRIPTION
- Add `getSystemStats()` to apps/web/src/lib/data/stats.ts as a cached server data function reading Postgres + Redis directly (no Hono round-trip)
- Delete the disabled `/stats` Hono route and its commented import/mount in apps/api
- Trim apps/api stats.service.ts to the notification/release increment counters still used by release-check.ts